### PR TITLE
Adding site's Base URL in menu item links

### DIFF
--- a/_layouts/project-nav.html.haml
+++ b/_layouts/project-nav.html.haml
@@ -14,11 +14,11 @@ title: Project Navigation
 			.nav-collapse.collapse
 				%ul.nav
 					%li.active<
-						%a(href="index.html") Home
+						%a(href="#{site.base_url}/index.html") Home
 					%li<
-						%a(href="downloads.html") Downloads
+						%a(href="#{site.base_url}/downloads.html") Downloads
 					%li<
-						%a(href="docs.html") Docs
+						%a(href="#{site.base_url}/docs.html") Docs
 					%li.dropdown
 						%a.dropdown-toggle(href="#" data-toggle="dropdown")<
 							= precede 'Community ' do
@@ -35,11 +35,11 @@ title: Project Navigation
 							%li<
 								%a(href="#") Blog
 					%li<
-						%a(href="issues.html") Issues
+						%a(href="#{site.base_url}/issues.html") Issues
 					%li<
-						%a(href="source.html") Source Code
+						%a(href="#{site.base_url}/source.html") Source Code
 					%li<
-						%a(href="build.html") Build
+						%a(href="#{site.base_url}/build.html") Build
 					%li.dropdown
 						%a.dropdown-toggle(href="#" data-toggle="dropdown")<
 							= precede 'Follow Us ' do


### PR DESCRIPTION
This is required if the site is not deployed at the root context. Eg., on github pages
where the context is http://<username>.github.io/<repo_name>
