### PR TITLE
Fixing problem when no page matches the given path

### DIFF
--- a/_ext/breadcrumb.rb
+++ b/_ext/breadcrumb.rb
@@ -40,20 +40,20 @@ module Awestruct
             return page
           end
         end
-
+        return nil
       end
 
       def generateAnchorHtml(page)
+        unless page.nil?
+          page = page.real_page if page.real_page != nil
 
-        page = page.real_page if page.real_page != nil
+          path = page.output_path == nil ? page.url : page.output_path
 
-        path = page.output_path == nil ? page.url : page.output_path
+          return "" if path==nil
 
-        return "" if path==nil
-
-        "<a class='breadcrumb_anchor' href='#{site.base_url}#{page.output_path}'
-        >#{page.title ? page.title : page.simple_name.capitalize }</a> / "
-
+          "<a class='breadcrumb_anchor' href='#{site.base_url}#{page.output_path}'
+          >#{page.title ? page.title : page.simple_name.capitalize }</a> / "
+        end
       end
 
     end


### PR DESCRIPTION
When no page matches the given path in the 'findInPages(path)',
an array containing 'site.pages' would be returned, which causes
an error later in the 'generateAnchorHtml(page)' method when
calling the 'real_page' attribute on the given parameter:

NoMethodError: undefined method `real_page' for #<Array:0x007fa64d2e8e98>
/Users/xcoulon/code/jbosstools/jbosstools-website/_ext/breadcrumb.rb:49:in`generateAnchorHtml'
/Users/xcoulon/code/jbosstools/jbosstools-website/_ext/breadcrumb.rb:15:in `breadcrumb'
/Users/xcoulon/code/jbosstools/jbosstools-website/_partials/nav.html.haml:69:in`block in singletonclass'
/Users/xcoulon/code/jbosstools/jbosstools-website/_partials/nav.html.haml:65528:in `instance_eval'
/Users/xcoulon/code/jbosstools/jbosstools-website/_partials/nav.html.haml:65528:in`singletonclass'
/Users/xcoulon/code/jbosstools/jbosstools-website/_partials/nav.html.haml:65526:in `__tilt_70176108346320'
/U
