### PR TITLE
Fixing minifiers when file has no extension

### DIFF
--- a/_ext/css_minifier.rb
+++ b/_ext/css_minifier.rb
@@ -42,37 +42,39 @@ module Awestruct
 
         # Test if it's a CSS file.
         ext = File.extname(page.output_path)
-        if !ext.empty?
+        
+        # skip if the file has no extension
+        if ext.empty?
+          return input
+        end
+        
+        ext_txt = ext[1..-1]
 
-          ext_txt = ext[1..-1]
-
-          # Filtering out non-css files and those which were already minimized with added suffix.
-          if ext_txt == "css" and !page.output_path.to_s.end_with?("min.css")
-            print "Minifying css #{page.output_path} \n"
-            output = CSSminify.compress(input)
-          else
-            return input
-          end
+        # Filtering out non-css files and those which were already minimized with added suffix.
+        if ext_txt == "css" and !page.output_path.to_s.end_with?("min.css")
+          print "Minifying css #{page.output_path} \n"
+          output = CSSminify.compress(input)
+        else
+          return input
+        end
 
         oldFileName = File.basename(page.output_path).to_s
 
-          # Create new file name with suffix added
-          newFileName = oldFileName.slice(0..oldFileName.length-4)+"min.css"
-          newOutputPath = File.join(File.dirname(page.output_path.to_s),newFileName)
+        # Create new file name with suffix added
+        newFileName = oldFileName.slice(0..oldFileName.length-4)+"min.css"
+        newOutputPath = File.join(File.dirname(page.output_path.to_s),newFileName)
 
-          # Create a temporary file with the merged content.
-          tmpOutputPath = File.join( "./_tmp/" , newFileName)
-          tmpOutputFile = File.new(tmpOutputPath,"w")
-          tmpOutputFile.write(output)
-          tmpOutputFile.close
+        # Create a temporary file with the merged content.
+        tmpOutputPath = File.join( "./_tmp/" , newFileName)
+        tmpOutputFile = File.new(tmpOutputPath,"w")
+        tmpOutputFile.write(output)
+        tmpOutputFile.close
 
-          # Add the temporary file to the list of pages for rendering phase.
-          newPage = site.engine.load_page(tmpOutputPath)
-          newPage.source_path = tmpOutputPath
-          newPage.output_path = newOutputPath
-          site.pages << newPage
-
-        end
+        # Add the temporary file to the list of pages for rendering phase.
+        newPage = site.engine.load_page(tmpOutputPath)
+        newPage.source_path = tmpOutputPath
+        newPage.output_path = newOutputPath
+        site.pages << newPage
 
         # We return the input because we leave the original file untouched
         input

--- a/_ext/js_minifier.rb
+++ b/_ext/js_minifier.rb
@@ -41,39 +41,39 @@ module Awestruct
 
         output = ''
 
-        # Test if it's a javascript file.
         ext = File.extname(page.output_path)
-        
-        if !ext.empty?
-          ext_txt = ext[1..-1]
-
-          # Filtering out non-css files and those which were already minimized with added suffix.
-          if ext_txt == "js" and !page.output_path.to_s.end_with?("min.js")
-            print "Minifying javascript #{page.output_path} \n"
-            output = Uglifier.new.compile(input)
-          else
-            return input
-          end
-
-          oldFileName = File.basename(page.output_path).to_s
-
-          # Create new file name with suffix added
-          newFileName = oldFileName.slice(0..oldFileName.length-3)+"min.js"
-          newOutputPath = File.join(File.dirname(page.output_path.to_s),newFileName)
-
-          # Create a temporary file with the merged content.
-          tmpOutputPath = File.join( "./_tmp/" , newFileName)
-          tmpOutputFile = File.new(tmpOutputPath,"w")
-          tmpOutputFile.write(output)
-          tmpOutputFile.close
-
-          # Add the temporary file to the list of pages for rendering phase.
-          newPage = site.engine.load_page(tmpOutputPath)
-          newPage.source_path = tmpOutputPath
-          newPage.output_path = newOutputPath
-          site.pages << newPage
-
+        # skip if the file has no extension
+        if ext.empty?
+          return input
         end
+
+        ext_txt = ext[1..-1]
+
+        # Filtering out non-js files and those which were already minimized with added suffix.
+        if ext_txt == "js" and !page.output_path.to_s.end_with?("min.js")
+          print "Minifying javascript #{page.output_path} \n"
+          output = Uglifier.new.compile(input)
+        else
+          return input
+        end
+
+        oldFileName = File.basename(page.output_path).to_s
+
+        # Create new file name with suffix added
+        newFileName = oldFileName.slice(0..oldFileName.length-3)+"min.js"
+        newOutputPath = File.join(File.dirname(page.output_path.to_s),newFileName)
+
+        # Create a temporary file with the merged content.
+        tmpOutputPath = File.join( "./_tmp/" , newFileName)
+        tmpOutputFile = File.new(tmpOutputPath,"w")
+        tmpOutputFile.write(output)
+        tmpOutputFile.close
+
+        # Add the temporary file to the list of pages for rendering phase.
+        newPage = site.engine.load_page(tmpOutputPath)
+        newPage.source_path = tmpOutputPath
+        newPage.output_path = newOutputPath
+        site.pages << newPage
 
         # We return the input because we leave the original file untouched
         input


### PR DESCRIPTION
The following error would occur on Ruby 1.9.3 + awestruct 0.5.5:

An error occurred: can't convert nil into String
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/page.rb:167:in `digest'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/page.rb:167:in`hexdigest'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/page.rb:167:in `rendered_content'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/engine.rb:285:in`generate_page'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/engine.rb:273:in `block in generate_output'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/engine.rb:270:in`each'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/engine.rb:270:in `generate_output'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/engine.rb:79:in`run'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/cli/generate.rb:21:in `run'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/cli/invoker.rb:125:in`invoke_generate'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/lib/awestruct/cli/invoker.rb:49:in `invoke!'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/gems/awestruct-0.5.5/bin/awestruct:9:in`<top (required)>'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/bin/awestruct:23:in `load'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/bin/awestruct:23:in`<main>'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/bin/ruby_executable_hooks:15:in `eval'
/Users/xcoulon/.rvm/gems/ruby-1.9.3-p484@jbosstools-website/bin/ruby_executable_hooks:15:in`<main>'
